### PR TITLE
Add community membership

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -7,9 +7,9 @@ Dapr. The Dapr project is subdivided into subprojects under
 
 | **Role**   | **Responsibilities**                                  | **Requirements**                                             | **Defined by**                                               |
 | ---------- | ----------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| member     | active contributor in the community.  reviewer of PRs | sponsored by 2 approvers or maintainers. multiple contributions to the project. | Dapr GitHub org member.                             |
-| approver   | approve accepting contributions                       | highly experienced and active reviewer + contributor to a subproject | [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) in GitHub |
-| maintainer | set direction and priorities for a subproject         | demonstrated responsibility and excellent technical judgement for the subproject | [CODEOWNERS](https://help.github.com/en/articles/about-code-owners), GitHub Team and repo ownership in GitHub |
+| Member     | Active contributor in the community.  reviewer of PRs | Sponsored by two approvers or maintainers. multiple contributions to the project. | Dapr GitHub org member.                             |
+| Approver   | Approve accepting contributions                       | Highly experienced and active reviewer + contributor to a subproject | [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) in GitHub |
+| Maintainer | Set direction and priorities for a subproject         | Demonstrated responsibility and excellent technical judgement for the subproject | [CODEOWNERS](https://help.github.com/en/articles/about-code-owners), GitHub Team and repo ownership in GitHub |
 
 *Note: The Technical & Streeting Committee (TSC) referred to in this document is not yet established. The interim members are @msfussell, @sarahnovotny, @yaron2.*
 
@@ -49,10 +49,10 @@ Defined by: Member of the Dapr GitHub organization
 - Have read the [contributor
   guide](https://github.com/dapr/dapr/blob/master/CONTRIBUTING.md)
 - Actively contributing to 1 or more subprojects.
-- Sponsored by 2 approvers. Note the following requirements for sponsors:
+- Sponsored by two approvers or maintainers (sponsors). Note the following requirements for sponsors:
   - Sponsors must have close interactions with the prospective member - e.g.
     code/design/proposal review, coordinating on issues, etc.
-  - Sponsors must be approvers or maintainers in at least 1 CODEOWNERS file
+  - Sponsors must be approvers or maintainers in at least one CODEOWNERS file
     in any repo in the Dapr org.
 - [Open an
   issue](https://github.com/dapr/community/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20for%20%3Cyour-GH-handle%3E)
@@ -73,9 +73,9 @@ Defined by: Member of the Dapr GitHub organization
 - Responsive to issues and PRs assigned to them
 - Active owner of code they have contributed (unless ownership is explicitly
   transferred)
-  - Code is well tested
-  - Tests consistently pass
-  - Addresses bugs or issues discovered after code is accepted
+  - Code is well tested.
+  - Tests consistently pass.
+  - Addresses bugs or issues discovered after code is accepted.
   - Members are encouraged to review and approve via the GitHub workflow. This review work while not sufficient to merge a PR does accrue toward the Member becoming an Approver. Merge approval and final review are performed by an Approver.
 
 - Members can be assigned to issues and PRs, and people can ask members for
@@ -107,12 +107,12 @@ core components may have higher bar for becoming an approver.
 The following apply to the part of the codebase for which one would be an
 approver in the `CODEOWNERS` files.
 
-- Reviewer of the codebase for at least 1 month
+- Reviewer of the codebase for at least 1 month.
 - Reviewer for or author of at least 5 substantial PRs to the codebase,
   with the definition of substantial subject to the maintainer's discretion
   (e.g. refactors/adds new functionality rather than one-line pulls).
 - Nominated by a maintainer
-  - With no objections from other maintainers
+  - With no objections from other maintainers.
   - Done through PR to update the `CODEOWNERS`.
 
 ### Responsibilities and privileges
@@ -120,14 +120,14 @@ approver in the `CODEOWNERS` files.
 The following apply to the part of the codebase for which one would be an
 approver in the `CODEOWNERS` files.
 
-- Approver status may be a precondition to accepting large code contributions
-- Demonstrate sound technical judgement (may be asked to step down by a maintainer if they lose confidence of the maintainers)
-- Responsible for project quality control via code reviews
+- Approver status may be a precondition to accepting large code contributions.
+- Demonstrate sound technical judgement (may be asked to step down by a maintainer if they lose confidence of the maintainers).
+- Responsible for project quality control via code reviews.
   - Focus on holistic acceptance of contribution such as dependencies with other
-    features, backwards / forwards compatibility, API and conventions, etc
+    features, backwards / forwards compatibility, API and conventions, etc.
 - Expected to be responsive to review requests (inactivity for more than 1 month may result in suspension until active again)
-- Mentor contributors and reviewers
-- May approve code contributions for acceptance
+- Mentor contributors and reviewers.
+- May approve code contributions for acceptance.
 
 ## Maintainer
 
@@ -144,22 +144,22 @@ files.
 
 The following apply to the subproject for which one would be an owner.
 
-- Deep understanding of the technical goals and direction of the subproject
+- Deep understanding of the technical goals and direction of the subproject.
 - Deep understanding of the technical domain (specifically the language) of the
-  subproject
+  subproject.
 - Sustained contributions to design and direction by doing all of:
-  - Authoring and reviewing proposals
+  - Authoring and reviewing proposals.
   - Initiating, contributing and resolving discussions (emails, GitHub issues,
-    meetings)
-  - Identifying subtle or complex issues in designs and implementation PRs
-- Directly contributed to the subproject through implementation and / or review
+    meetings).
+  - Identifying subtle or complex issues in designs and implementation PRs.
+- Directly contributed to the subproject through implementation and / or review.
 - Aligning with the overall project goals, specifications and design principles
   defined by the Technical & Steering Committee. Bringing general questions and requests
   to the discussions as part of specifications project.
 
 ### Responsibilities and privileges
 
-The following apply to the subproject for which one would be an owner.
+The following apply to the subproject(repos) for which one would be an owner.
 
 - Make and approve technical design decisions for the subproject.
 - Set technical direction and priorities for the subproject.
@@ -169,8 +169,8 @@ The following apply to the subproject for which one would be an owner.
 - Escalate *approver* and *maintainer* workflow concerns (i.e. responsiveness,
   availability, and general contributor community health) to the TC.
 - Ensure continued health of subproject:
-  - Adequate test coverage to confidently release
-  - Tests are passing reliably (i.e. not flaky) and are fixed when they fail
+  - Adequate test coverage to confidently release.
+  - Tests are passing reliably (i.e. not flaky) and are fixed when they fail.
 - Ensure a healthy process for discussion and decision making is in place.
 - Work with other maintainers to maintain the project's overall health and
   success holistically.


### PR DESCRIPTION
This PR contains a community membership section based on the [OpenTelemetry](https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md) membership doc.

Closes #2 