### PR TITLE
Remove steering committee email

### DIFF
--- a/steering-and-technical-committee-charter.md
+++ b/steering-and-technical-committee-charter.md
@@ -212,14 +212,7 @@ symptom of a larger problem in the community that will need to be addressed.
 
 ## Getting in touch
 
-There are two ways to raise issues to the steering committee for decision:
-
-1. Emailing the steering and technical committee at
-   [steering.technical@dapr.io](mailto:steering.technica@dapr.io).
-   This is a private discussion list to which all members of the committee have
-   access.
-2. Open an issue on any Dapr repository and indicate that you would like
-   attention from the steering and technical committee.
+Open an issue on this community repository and mention any steering member from the [list](#committee-members).
 
 ---
 


### PR DESCRIPTION
The steering committee email (steering.technical@dapr.io) is currently hosted at a Microsoft Office365 account.
This email group is already out of date, and the process of changing goes through needing to contact a specific Microsoft employee who has access to the group and change it. This is cumbersome and doesn't scale well.

For now, this PR removes the reference to this group and points at creating an issue in the community repository as the way to address the STC.
Now that Dapr is in CNCF, we can initiate a service desk request to create an email group for our domain which will be transferred CNCF as well as part of the onboarding process.