### PR TITLE
Updated Yaron and Mark's org from Independent to Diagrid

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,8 +2,8 @@
 
 This is the list of maintainers for all Dapr repositories:
 
-- Yaron Schneider (Independent) [@yaron2](https://github.com/yaron2)
-- Mark Fussell (Independent) [@msfussell](https://github.com/msfussell) 
+- Yaron Schneider (Diagrid) [@yaron2](https://github.com/yaron2)
+- Mark Fussell (Diagrid) [@msfussell](https://github.com/msfussell) 
 - Long Dai (Intel) [@daixiang0](https://github.com/daixiang0)
 - Xavier Geernick (Tinx.AI) [@XavierGeerinck](https://github.com/XavierGeerinck)
 - Rob Landers (Automattic) [@withinboredom](https://github.com/withinboredom)


### PR DESCRIPTION
updated the company affiliation for both Yaron and Mark from "Independent" to "Diagrid" for more accurate maintainer tracking