### PR TITLE
fix extract metrics failure

### DIFF
--- a/.github/scripts/github_issues_metrics.py
+++ b/.github/scripts/github_issues_metrics.py
@@ -106,7 +106,7 @@ not_triaged_bugs = []
 
 for repo in my_repos:
     # discover milestone project
-    issues = [i for i in g.get_repo('dapr/' + repo).get_issues(labels=['kind/bug'], since=issues_since) if i.created_at >= issues_since]
+    issues = [i for i in g.get_repo('dapr/' + repo).get_issues(labels=['kind/bug'], since=issues_since) if i.created_at >= issues_since.astimezone(i.created_at.tzinfo)]
     total_count += len(issues)
 
     for issue in issues:
@@ -119,9 +119,9 @@ for repo in my_repos:
                 if canonical_label not in first_label_events:
                     first_label_events[canonical_label] = event.created_at
         triaged_time = get_triaged_time(first_label_events)
-        time_to_triage = triaged_time - issue.created_at
+        time_to_triage = triaged_time.astimezone(issue.created_at.tzinfo) - issue.created_at
         expected_total_time_to_triage += time_to_triage
-        age_str = humanize.naturaldelta(now - issue.created_at)
+        age_str = humanize.naturaldelta(now.astimezone(issue.created_at.tzinfo) - issue.created_at)
         bug = {
                 'url': issue.html_url,
                 'age': age_str,


### PR DESCRIPTION
Currently the workflow `GitHub Metrics for Dapr's repositories` always fail due to the following logs:

```
== APP == Traceback (most recent call last):
== APP ==   File "/home/runner/work/community/community/./.github/scripts/github_issues_metrics.py", line 109, in <module>
== APP ==     issues = [i for i in g.get_repo('dapr/' + repo).get_issues(labels=['kind/bug'], since=issues_since) if i.created_at >= issues_since]
== APP ==   File "/home/runner/work/community/community/./.github/scripts/github_issues_metrics.py", line 109, in <listcomp>
== APP ==     issues = [i for i in g.get_repo('dapr/' + repo).get_issues(labels=['kind/bug'], since=issues_since) if i.created_at >= issues_since]
== APP == TypeError: can't compare offset-naive and offset-aware datetimes
```

[For more failure detais](https://github.com/dapr/community/actions/workflows/github_metrics.yml)

I added time zone to variables in the script to avoid this failure.