### PR TITLE
Fix matrics extract failure

### DIFF
--- a/.github/scripts/github_issues_metrics.py
+++ b/.github/scripts/github_issues_metrics.py
@@ -141,7 +141,7 @@ for repo in my_repos:
                 issue.html_url, age_str, humanize.naturaldelta(time_to_triage)))
         bugs.append(bug)
 
-average_days_to_triage = (total_time_to_triage / triaged_count).total_seconds() / ONE_DAY.total_seconds()
+average_days_to_triage = (total_time_to_triage / triaged_count).total_seconds() / ONE_DAY.total_seconds() if triaged_count != 0 else 30
 expected_average_days_to_triage = (expected_total_time_to_triage / total_count).total_seconds() / ONE_DAY.total_seconds()
 triaged_under_5_days_ratio = triaged_under_5_days_count / total_count
 


### PR DESCRIPTION
when all bug issues are not triaged there will be zero division error in our metrics collect workflow.

for more details refer to :https://github.com/dapr/community/actions/runs/7380805130/job/20078586488

I set `average_days_to_triage` to maximun(30) when no issue is triaged to avoid this kind of error. 