### PR TITLE
update: move the release/milestone & design meeting to 9am PT

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ We are using a different link from Community Call because the Community Call req
 **Zoom Call:** https://zoom.us/j/91940016938<br> <!-- Do not add password to the Zoom URL. -->
 **Meeting ID:** 919 4001 6938<br>
 **Passcode:** 152697<br> 
-**Schedule:** Tuesdays at 7:30am Pacific Time.
+**Schedule:** Tuesdays at 9:00am US/Pacific Time (PT).
 
 Visit [here](https://github.com/dapr/community/blob/master/release-process.md) to learn more about the Dapr release process.
 


### PR DESCRIPTION
Moves the meeting time to 9AM PT for 1.14 the upcoming 1.14 release to align with schedules