### PR TITLE
Add roadmap and remove outdated info

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -1,6 +1,5 @@
 # Release cycle and cadence 
-The Dapr project aims to release four updates in a yearly time period, typically one in each quarter (every 3 months). For example in 2022 the minor releases were Jan (1.6.0), April (1.7.0), July (1.8.0), Oct (1.9.0) and the same is expected for 2023.
-
+The Dapr project aims to release four updates in a yearly time period, typically one in each quarter (every 3 months).
 
 <img src="images/release-cycle-diagram.png?raw=true">
 
@@ -39,8 +38,7 @@ On assignment, the release team lead and shadow(s) are included into the Github 
 - [ ] Communicating status to the community on an on-going basis.
 
 
-[
-- Read about the K8s release team selection [here](https://github.com/kubernetes/sig-release/blob/master/release-team/release-team-selection.md#selection-criteria)]
+Read about the K8s release team selection [here](https://github.com/kubernetes/sig-release/blob/master/release-team/release-team-selection.md#selection-criteria).
 
 ## Feature definition phase (~2 weeks)
 With ongoing feature definition, some set of issues will bubble up as targeting a given release. In this phase, a set of feature proposals and significant design changes to existing features are reviewed where contributors are able to dedicate time to completing the issue or starting an issue for a future release. 

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,10 +1,10 @@
 # Dapr Roadmap
 
-This document outlines the high-level roadmap for the Dapr project. The roadmap is subject to change and is not a commitment to deliver any specific features or timelines.
-
-[GitHub milestones](https://github.com/dapr/dapr/milestones) are created for each release and are named after the release version. GitHub issues are assigned to a milestone to track the scope and progress of a release.
+This document outlines the high-level roadmap for the Dapr project. The roadmap is subject to change and is not a commitment to deliver any specific features or timelines. The roadmap is updated every quarter, after a release.
 
 ## Releases
+
+[GitHub milestones](https://github.com/dapr/dapr/milestones) are created for each release and are named after the release version. GitHub issues are assigned to a milestone to track the scope and progress of a release.
 
 ### Current Release
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,29 @@
+# Dapr Roadmap
+
+This document outlines the high-level roadmap for the Dapr project. The roadmap is subject to change and is not a commitment to deliver any specific features or timelines.
+
+[GitHub milestones](https://github.com/dapr/dapr/milestones) are created for each release and are named after the release version. GitHub issues are assigned to a milestone to track the scope and progress of a release.
+
+## Releases
+
+### Current Release
+
+The current Dapr release is v1.13. Details can be found in the [release notes](https://github.com/dapr/dapr/releases/tag/v1.13.0).
+
+### Next Release
+
+The next release is v1.14. This release is currently in development. The [release planning](https://github.com/dapr/dapr/issues/7605) issue contains milestone dates, and the features and enhancements planned for this release.
+
+### Future Releases
+
+Features or important changes for future releases include:
+
+- Extend the State Management (K/V) API with a `list` operation to list keys based on a prefix.
+- Introduce a document store API that supports querying.
+- Introduce a blob store API.
+
+New ideas and improvements are always welcome. Please check the existing issues in the relevant Dapr repositories before submitting a new issue with your idea. New APIs or breaking changes to the Dapr runtime should be submitted as proposals in the [dapr/proposals](https://github.com/dapr/proposals) repository.
+
+## Release process
+
+The release cycle and cadence for Dapr is described in [Release Process](release-process.md).


### PR DESCRIPTION
The **Future releases** part of the roadmap needs a few more bullet points of features that are likely to be added in 1.15 / 1.16.