### PR TITLE
docs: update maintainer and release meeting Zoom links to LFX platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Every week, we meet to plan and sync on the progress for the milestone's release
 <!--
 We are using a different link from Community Call because the Community Call requires the host to admit each person. In the weekly syncs, we "never" login with the host account.
 -->
-**Zoom Call:** https://zoom.us/j/91940016938<br> <!-- Do not add password to the Zoom URL. -->
-**Meeting ID:** 919 4001 6938<br>
-**Passcode:** 152697<br> 
+**Zoom Call:** https://zoom-lfx.platform.linuxfoundation.org/meeting/96780898261<br> <!-- Do not add password to the Zoom URL. -->
+**Meeting ID:** 967 8089 8261<br>
+**Passcode:** 310351<br> 
 **Schedule:** Tuesdays at 9:00am US/Pacific Time (PT).
 
 Visit [here](https://github.com/dapr/community/blob/master/release-process.md) to learn more about the Dapr release process.
@@ -87,8 +87,8 @@ Visit [here](https://github.com/dapr/community/blob/master/release-process.md) t
 
 Every Monday at 9 am US/Pacific maintainers meet privately to discuss project priorities and concerns. New maintainers will receive access to the **Maintainers** channel in our Discord server where the meeting passcode will be shared.
 
-**Zoom Call:** https://zoom.us/j/91911083168<br> <!-- Do not add password to the Zoom URL. -->
-**Meeting ID:** 919 1108 3168<br>
+**Zoom Call:** https://zoom-lfx.platform.linuxfoundation.org/meeting/93184256679<br> <!-- Do not add password to the Zoom URL; the maintainers passcode is shared privately in Discord. -->
+**Meeting ID:** 931 8425 6679<br>
 **Passcode:** Shared in **Maintainers** Discord channel<br> 
 **Schedule:** Mondays at 9am US/Pacific Time.
 


### PR DESCRIPTION
## What this does

Updates the two Zoom meeting entries in the README to the new LFX-hosted meetings:

| Meeting | Section | New meeting ID |
|---|---|---|
| Weekly release / milestone sync (Tuesdays 9am PT) | *Milestone and design discussion meetings* | `967 8089 8261` |
| Maintainers-only sync (Mondays 9am PT) | *Maintainers Only Sync Meeting* | `931 8425 6679` |

Both meetings have migrated from `zoom.us/j/...` to the LFX platform (`zoom-lfx.platform.linuxfoundation.org/meeting/...`). The release meeting passcode is updated to `310351`.

## Note on the maintainers meeting passcode

Following the existing convention in this file, the **maintainers-only** passcode is **not** published here — it stays in the **Maintainers** Discord channel, and the embedded `?password=` is deliberately stripped from that URL so the private passcode isn't leaked in a public repo. Only the meeting ID (already public before) and the base URL are updated.

The release/milestone meeting is a public meeting, so its passcode continues to be listed inline as before.

## Scope

`README.md` only. The other meeting references in the repo (`release-process.md`, `community-manager-onboarding-2.md`) describe schedules/purpose and don't embed Zoom links, so no changes are needed there.
